### PR TITLE
CONCPP-96 The fix and testcase

### DIFF
--- a/src/MariaDBException.cpp
+++ b/src/MariaDBException.cpp
@@ -258,7 +258,7 @@ namespace sql
   {}
 
   ParseException::ParseException(const ParseException& other) :
-    SQLException(other)
+    SQLException(other), position(other.position)
   {}
 
   ParseException::ParseException(const SQLString& str, std::size_t pos) :
@@ -271,7 +271,7 @@ namespace sql
   {}
 
   MaxAllowedPacketException::MaxAllowedPacketException(const MaxAllowedPacketException& other) :
-    std::runtime_error(other)
+    std::runtime_error(other), mustReconnect(other.mustReconnect)
   {}
 
   MaxAllowedPacketException::MaxAllowedPacketException(const char* message, bool _mustReconnect)
@@ -281,7 +281,7 @@ namespace sql
   }
 
   /////////////////////////////
-  MariaDBExceptionThrower::MariaDBExceptionThrower(MariaDBExceptionThrower&& moved) : exceptionThrower(std::move(moved.exceptionThrower))
+  MariaDBExceptionThrower::MariaDBExceptionThrower(MariaDBExceptionThrower&& moved) noexcept : exceptionThrower(std::move(moved.exceptionThrower))
   {}
 
   void MariaDBExceptionThrower::assign(MariaDBExceptionThrower other) {

--- a/src/MariaDBException.h
+++ b/src/MariaDBException.h
@@ -70,7 +70,7 @@ public:
     exceptionThrower.reset(new RealThrower<T>(exc));
   }
   
-  MariaDBExceptionThrower(MariaDBExceptionThrower&& moved);
+  MariaDBExceptionThrower(MariaDBExceptionThrower&& moved) noexcept;
   void assign(MariaDBExceptionThrower other);
   template <class T> T* get() { return dynamic_cast<T*>(exceptionThrower->get()); }
   SQLException* getException() { return exceptionThrower->get(); }

--- a/src/parameters/DoubleParameter.cpp
+++ b/src/parameters/DoubleParameter.cpp
@@ -19,6 +19,7 @@
 
 
 #include "DoubleParameter.h"
+#include <iomanip>
 
 namespace sql
 {
@@ -35,7 +36,7 @@ namespace mariadb
   {
     //std::to_string is not precise enough. at least on windows it does just sprintf("%f")
     std::stringstream doubleAsString("");
-    doubleAsString << value;
+    doubleAsString << std::setprecision(30) << value;
     str.append(doubleAsString.str().c_str());
   }
 

--- a/test/CJUnitTestsPort/compliance/DatabaseMetaDataTest.cpp
+++ b/test/CJUnitTestsPort/compliance/DatabaseMetaDataTest.cpp
@@ -7305,8 +7305,7 @@ void DatabaseMetaDataTest::testSupportsFullOuterJoins()
     logMsg("supportsFullOuterJoins method is supported");
     if (!dbmd->supportsLimitedOuterJoins())
     {
-      FAIL("supportsLimitedOuterJoins() must "
-           + "be true if supportsFullOuterJoins() " + "is true!");
+      FAIL("supportsLimitedOuterJoins() must be true if supportsFullOuterJoins() is true!");
     }
   } else {
     logMsg("supportsFullOuterJoins method is not supported");

--- a/test/framework/test_asserts.cpp
+++ b/test/framework/test_asserts.cpp
@@ -227,7 +227,7 @@ void assertEqualsEpsilon(const long double & expected, const long double & resul
   std::stringstream errmsg;
   errmsg.str("");
   errmsg << "assertEquals(double) failed in " << file << ", line #" << line;
-  errmsg << " expecting '" << expected << "' got '" << result << "'";
+  errmsg << " expecting '" << std::setprecision(9) << expected << "' got '" << result << "'";
   TestsListener::testHasFailed(errmsg.str());
 }
 
@@ -246,7 +246,7 @@ void assertEqualsEpsilon(const double & expected, const double & result
   std::stringstream errmsg;
   errmsg.str("");
   errmsg << "assertEquals(double) failed in " << file << ", line #" << line;
-  errmsg << " expecting '" << expected << "' got '" << result << "'";
+  errmsg << " expecting '" << std::setprecision(9) << expected << "' got '" << result << "'";
   TestsListener::testHasFailed(errmsg.str());
 }
 

--- a/test/unit/classes/connection.cpp
+++ b/test/unit/classes/connection.cpp
@@ -59,7 +59,7 @@ void connection::getClientInfo()
 
     //ret= con->getClientInfo();
     if (ret != "cppconn")
-      FAIL("Expecting 'cppconn' got '" + ret + "'.");
+      FAIL(("Expecting 'cppconn' got '" + ret + "'.").c_str());
 
   }
   catch (sql::SQLException &e)
@@ -1203,7 +1203,7 @@ void connection::connectUsingMap()
           con.reset(driver->connect(connection_properties));
           schema=con->getSchema();
           if (!schema.empty())
-            FAIL("Empty schama specified but certain schema selected upon connect");
+            FAIL("Empty schema specified but certain schema selected upon connect");
         }
         catch (sql::SQLException &)
         {

--- a/test/unit/classes/preparedstatementtest.h
+++ b/test/unit/classes/preparedstatementtest.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ *               2020, 2022 MariaDB Corporation AB
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License, version 2.0, as
@@ -49,6 +50,8 @@ class preparedstatement : public unit_fixture
 private:
   typedef unit_fixture super;
   bool createSP(std::string sp_code);
+  Connection sspsCon;
+  PreparedStatement ssps;
 
 public:
 
@@ -69,6 +72,7 @@ public:
     TEST_CASE(blob);
     TEST_CASE(executeQuery);
     TEST_CASE(addBatch);
+    TEST_CASE(bugConcpp96);
   }
 
   /**
@@ -144,6 +148,11 @@ public:
   void executeQuery();
 
   void addBatch();
+
+  void bugConcpp96();
+
+  /* unit_fixture methods redefinitions */
+  void setUp();
 };
 
 REGISTER_FIXTURE(preparedstatement);

--- a/test/unit/unit_fixture.cpp
+++ b/test/unit/unit_fixture.cpp
@@ -340,9 +340,9 @@ void unit_fixture::setUp()
            + " " + String(driver->getMajorVersion() + driver->getMajorVersion + String(".") + driver->getMinorVersion());*/
 
   con->setSchema(db);
-
   stmt.reset(con->createStatement());
 }
+
 
 void unit_fixture::tearDown()
 {


### PR DESCRIPTION
The fix sets precision 30 for conversion of the double number to its
string representation, requeired for "client side" statement preparing(server
side wasn't affected by the bug). 30 is taked because it's max number of
decimals for decimal column type. This can cause "overflow" errors if
setDouble is used to populate shorter varchar or other types. SOme older
test have been amended to deal with that.
Testframework was fixed to be more informative about where the error
occured(often it printed line where the exception was caught, and for
some tests that is not very helpful.
Fixed couple of compilation warnings.